### PR TITLE
Add telemetry report

### DIFF
--- a/.atoum.php
+++ b/.atoum.php
@@ -3,16 +3,23 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'autoloader.php';
 
 use
 	mageekguy\atoum\reports,
-	mageekguy\atoum\reports\coverage
+	mageekguy\atoum\reports\coverage,
+	mageekguy\atoum\reports\telemetry,
+	mageekguy\atoum\writers\std
 ;
 
 $runner->addExtension(new reports\extension($script));
 $script->addDefaultReport();
 
 $coverage = new coverage\html();
-$coverage->addWriter(new \mageekguy\atoum\writers\std\out());
+$coverage->addWriter(new std\out());
 $coverage->setOutPutDirectory(__DIR__ . '/coverage');
 $runner->addReport($coverage);
+
+$telemetry = new telemetry();
+$telemetry->readProjectNameFromComposerJson(__DIR__ . '/composer.json');
+$telemetry->addWriter(new std\out());
+$runner->addReport($telemetry);
 
 $script->enableBranchAndPathCoverage();
 $script->noCodeCoverageForClasses('mageekguy\atoum\reports\asynchronous');

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
@@ -14,4 +12,4 @@ before_script:
   - composer install
 
 script:
-  - vendor/bin/atoum --test-ext
+  - vendor/bin/atoum --test-ext -p 'php -n'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.0.0 - 2015-04-30
+
+* [#4](https://github.com/atoum/reports-extension/pull/4) Add telemetry report ([@jubianchi])
+
+## BC break updates
+
+* [#4](https://github.com/atoum/reports-extension/pull/4) PHP `< 5.5.0` is not supported anymore ([@jubianchi])
+
 # 1.0.1 - 2015-09-16
 
 * Loosened constraint on symfony/filesystem
@@ -5,3 +13,5 @@
 # 1.0.0 - 2015-05-13
 
 * HTML Coverage report with branches and paths support
+
+[@jubianchi]: https://github.com/jubianchi

--- a/README.md
+++ b/README.md
@@ -33,11 +33,49 @@ $extension->addToRunner($runner);
 
 ## Use it
 
+### Telemetry report
+
+The telemetry report allow us to collect metrics from your test suites. If you want to help us improve atoum, please send us your reports.
+
+To enable the telemetry report, add the following code to your configuration file:
+
+```php
+<?php
+
+// .atoum.php
+
+use mageekguy\atoum\reports;
+use mageekguy\atoum\reports\telemetry;
+use mageekguy\atoum\writers\std;
+
+$script->addDefaultReport();
+
+$telemetry = new telemetry();
+$telemetry->addWriter(new std\out());
+$runner->addReport($telemetry);
+```
+
+Now, each time your run your test suite, atoum will collect data and send them to the telemtry. By default, **everything is
+sent anonymously**: a random project name will be generated and we'll only collect metrics. If you want to let us know who you are, add
+the following lines to your configuration file:
+
+```php
+<?php 
+
+$telemetry->readProjectNameFromComposerJson(__DIR__ . '/composer.json');
+
+// Or
+
+$telemetry->setProjectName('my/project');
+```
+
+The project name **must** be composer compliant.
+
 ### HTML coverage report
 
 **Check out the demo report generated with atoum's test suite: [http://atoum.github.io/reports-extension/](http://atoum.github.io/reports-extension/)**
 
-Add the following code to you configuration file :
+Add the following code to your configuration file:
 
 ```php
 <?php
@@ -46,11 +84,12 @@ Add the following code to you configuration file :
 
 use mageekguy\atoum\reports;
 use mageekguy\atoum\reports\coverage;
+use mageekguy\atoum\writers\std;
 
 $script->addDefaultReport();
 
 $coverage = new coverage\html();
-$coverage->addWriter(new \mageekguy\atoum\writers\std\out());
+$coverage->addWriter(new std\out());
 $coverage->setOutPutDirectory(__DIR__ . '/coverage');
 $runner->addReport($coverage);
 ```

--- a/autoloader.php
+++ b/autoloader.php
@@ -7,7 +7,15 @@ atoum\autoloader::get()
 	->addNamespaceAlias('atoum\reports', __NAMESPACE__)
 	->addDirectory(__NAMESPACE__, __DIR__ . DIRECTORY_SEPARATOR . 'classes')
 	->addDirectory('Symfony\Component\Filesystem', __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'symfony' . DIRECTORY_SEPARATOR . 'filesystem')
+	->addDirectory('GuzzleHttp', __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'guzzlehttp' . DIRECTORY_SEPARATOR . 'guzzle' . DIRECTORY_SEPARATOR . 'src')
+	->addDirectory('GuzzleHttp\Promise', __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'guzzlehttp' . DIRECTORY_SEPARATOR . 'promises' . DIRECTORY_SEPARATOR . 'src')
+	->addDirectory('GuzzleHttp\Psr7', __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'guzzlehttp' . DIRECTORY_SEPARATOR . 'psr7' . DIRECTORY_SEPARATOR . 'src')
+	->addDirectory('Psr\Http\Message', __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'psr' . DIRECTORY_SEPARATOR . 'http-message' . DIRECTORY_SEPARATOR . 'src')
 ;
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'guzzlehttp' . DIRECTORY_SEPARATOR . 'guzzle' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'functions_include.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'guzzlehttp' . DIRECTORY_SEPARATOR . 'promises' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'functions_include.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'guzzlehttp' . DIRECTORY_SEPARATOR . 'psr7' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'functions_include.php';
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'twig' . DIRECTORY_SEPARATOR . 'twig' . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'Twig' . DIRECTORY_SEPARATOR . 'Autoloader.php';
 

--- a/classes/telemetry.php
+++ b/classes/telemetry.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace mageekguy\atoum\reports;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use mageekguy\atoum;
+use mageekguy\atoum\reports\asynchronous;
+
+class telemetry extends asynchronous
+{
+	const defaultUrl = 'https://telemetry.atoum.org';
+
+	protected $client;
+	protected $score;
+	protected $testClassNumber = 0;
+	protected $testMethodNumber = 0;
+	protected $isAnonymous = true;
+	protected $projectFullName;
+	protected $projectVendorName;
+	protected $projectName;
+	protected $telemetryUrl;
+
+	public function __construct(Client $client = null)
+	{
+		parent::__construct();
+
+		$this->setTelemetryUrl();
+		$this->client = $client ?: new Client();
+	}
+
+	public function setTelemetryUrl($url = null)
+	{
+		$this->telemetryUrl = $url ?: static::defaultUrl;
+
+		return $this;
+	}
+
+	public function setProjectName($name)
+	{
+		if (!preg_match('/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/', $name))
+		{
+			throw new atoum\exceptions\logic\invalidArgument('Project name should match /^[a-z0-9_.-]+\/[a-z0-9_.-]+$/');
+		}
+
+		$parts = explode('/', $name);
+
+		$this->projectFullName = $name;
+		$this->projectVendorName = $parts[0];
+		$this->projectName = $parts[1];
+		$this->isAnonymous = false;
+
+		return $this;
+	}
+
+	public function readProjectNameFromComposerJson($path)
+	{
+		if (is_file($path) === false)
+		{
+			throw new atoum\exceptions\runtime($this->locale->_('File %s does not exists', realpath($path)));
+		}
+
+		$json = @file_get_contents($path);
+
+		if ($json === false)
+		{
+			throw new atoum\exceptions\runtime($this->locale->_('Could not read file %s', realpath($path)));
+		}
+
+		$json = @json_decode($json, true);
+
+		if ($json === false)
+		{
+			throw new atoum\exceptions\runtime($this->locale->_('Could not decode JSON from file %s', realpath($path)));
+		}
+
+		if (isset($json['name']) === false)
+		{
+			throw new atoum\exceptions\runtime($this->locale->_('Could not extract project name from file %s', realpath($path)));
+		}
+
+		$this->setProjectName($json['name']);
+
+		return $this;
+	}
+
+	public function sendAnonymousReport()
+	{
+		$this->isAnonymous = true;
+	}
+
+	public function handleEvent($event, atoum\observable $observable)
+	{
+		$this->score = $observable->getScore();
+
+		if ($event === atoum\test::runStart)
+		{
+			$this->testClassNumber++;
+		}
+
+		if ($event === atoum\test::beforeTestMethod)
+		{
+			$this->testMethodNumber++;
+		}
+
+		return parent::handleEvent($event, $observable);
+	}
+
+	public function build($event)
+	{
+		if ($event === atoum\runner::runStop && $this->score !== null)
+		{
+			if (($this->isAnonymous === true && $this->projectFullName !== null) || $this->projectFullName === null)
+			{
+				$this->setProjectName(uniqid('anon/', true));
+			}
+
+			$report = [
+				'php' => $this->score->getPhpVersion(),
+				'atoum' => $this->score->getAtoumVersion(),
+				'os' => php_uname('s') . ' ' . php_uname('r'),
+				'arch' => php_uname('m'),
+				'vendor' => $this->projectVendorName,
+				'project' => $this->projectName,
+				'metrics' => [
+					'classes' => $this->testClassNumber,
+					'methods' => [
+						'total' => $this->testMethodNumber,
+						'void' => $this->score->getVoidMethodNumber(),
+						'uncomplete' => $this->score->getUncompletedMethodNumber(),
+						'skipped' => count($this->score->getSkippedMethods()),
+						'failed' => count($this->score->getMethodsWithFail()),
+						'errored' => count($this->score->getMethodsWithError()),
+						'exception' => count($this->score->getMethodsWithException()),
+					],
+					'assertions' => [
+						'total' => $this->score->getAssertionNumber(),
+						'passed' => $this->score->getPassNumber(),
+						'failed' => $this->score->getFailNumber()
+					],
+					'exceptions' => $this->score->getExceptionNumber(),
+					'errors' => $this->score->getErrorNumber(),
+					'duration' => $this->score->getTotalDuration(),
+					'memory' => $this->score->getTotalMemoryUsage(),
+				]
+			];
+
+			try
+			{
+				$this->client->request('POST', $this->telemetryUrl, ['body' => json_encode($report)]);
+
+				$this->string = 'Your report has been sent to the telemetry. Thanks for sharing it with us!';
+			}
+			catch(RequestException $exception)
+			{
+				$this->string = 'Unable to send your report to the telemetry: HTTP ' . $exception->getCode();
+			}
+
+			$this->string .= PHP_EOL;
+		}
+
+		return $this;
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,10 @@
         }
     ],
     "require": {
+        "php": ">=5.5.0",
         "twig/twig": "~1.18",
-        "symfony/filesystem": "~2.6"
+        "symfony/filesystem": "~2.6",
+        "guzzlehttp/guzzle": "^6.2"
     },
     "require-dev": {
         "atoum/atoum": "~2.1"

--- a/tests/units/classes/telemetry.php
+++ b/tests/units/classes/telemetry.php
@@ -1,0 +1,333 @@
+<?php
+
+namespace mageekguy\atoum\reports\tests\units;
+
+use
+	mageekguy\atoum,
+	mageekguy\atoum\reports\telemetry as testedClass
+;
+
+class telemetry extends atoum\test
+{
+	public function testClass()
+	{
+		$this
+			->testedClass
+				->extends('mageekguy\atoum\reports\asynchronous')
+		;
+	}
+
+	public function testClassConstants()
+	{
+		$this
+			->string(testedClass::defaultUrl)->isEqualTo('https://telemetry.atoum.org')
+		;
+	}
+
+	public function testSetTelemetryUrl()
+	{
+		$this
+			->given(
+				$client = new \mock\GuzzleHttp\Client(),
+				$this->calling($client)->request->doesNothing,
+				$runner = new \mock\mageekguy\atoum\runner(),
+				$telemetry = $this->newTestedInstance($client)
+			)
+			->when($this->testedInstance->handleEvent(atoum\runner::runStop, $runner))
+			->then
+				->mock($client)->call('request')->withArguments('POST', testedClass::defaultUrl)->once
+			->if(
+				$url = uniqid(),
+				$this->testedInstance->setTelemetryUrl($url)
+			)
+			->when($this->testedInstance->handleEvent(atoum\runner::runStop, $runner))
+			->then
+				->mock($client)->call('request')->withArguments('POST', $url)->once
+		;
+	}
+
+	public function testSetProjectName()
+	{
+		$this
+			->given(
+				$client = new \mock\GuzzleHttp\Client(),
+				$this->calling($client)->request->doesNothing,
+				$runner = new \mock\mageekguy\atoum\runner(),
+				$telemetry = $this->newTestedInstance($client)
+			)
+			->if($this->function->uniqid = 'anon/' . ($project = uniqid()))
+			->when($this->testedInstance->handleEvent(atoum\runner::runStop, $runner))
+			->then
+				->mock($client)->call('request')->withArguments('POST', testedClass::defaultUrl, ['body' => json_encode([
+					'php' => null,
+					'atoum' => null,
+					'os' => php_uname('s') . ' ' . php_uname('r'),
+					'arch' => php_uname('m'),
+					'vendor' => 'anon',
+					'project' => $project,
+					'metrics' => [
+						'classes' => 0,
+						'methods' => [
+							'total' => 0,
+							'void' => 0,
+							'uncomplete' => 0,
+							'skipped' => 0,
+							'failed' => 0,
+							'errored' => 0,
+							'exception' => 0,
+						],
+						'assertions' => [
+							'total' => 0,
+							'passed' => 0,
+							'failed' => 0
+						],
+						'exceptions' => 0,
+						'errors' => 0,
+						'duration' => 0,
+						'memory' => 0
+					]
+				])])->once
+			->if(
+				$vendor = uniqid(),
+				$project = uniqid(),
+				$this->testedInstance->setProjectName($vendor . '/' . $project)
+			)
+			->when($this->testedInstance->handleEvent(atoum\runner::runStop, $runner))
+			->then
+				->mock($client)->call('request')->withArguments('POST', testedClass::defaultUrl, ['body' => json_encode([
+					'php' => null,
+					'atoum' => null,
+					'os' => php_uname('s') . ' ' . php_uname('r'),
+					'arch' => php_uname('m'),
+					'vendor' => $vendor,
+					'project' => $project,
+					'metrics' => [
+						'classes' => 0,
+						'methods' => [
+							'total' => 0,
+							'void' => 0,
+							'uncomplete' => 0,
+							'skipped' => 0,
+							'failed' => 0,
+							'errored' => 0,
+							'exception' => 0,
+						],
+						'assertions' => [
+							'total' => 0,
+							'passed' => 0,
+							'failed' => 0
+						],
+						'exceptions' => 0,
+						'errors' => 0,
+						'duration' => 0,
+						'memory' => 0
+					]
+				])])->once
+			->if(
+				$this->function->uniqid = 'anon/' . ($project = uniqid()),
+				$this->testedInstance->sendAnonymousReport()
+			)
+			->when($this->testedInstance->handleEvent(atoum\runner::runStop, $runner))
+			->then
+				->mock($client)->call('request')->withArguments('POST', testedClass::defaultUrl, ['body' => json_encode([
+					'php' => null,
+					'atoum' => null,
+					'os' => php_uname('s') . ' ' . php_uname('r'),
+					'arch' => php_uname('m'),
+					'vendor' => 'anon',
+					'project' => $project,
+					'metrics' => [
+						'classes' => 0,
+						'methods' => [
+							'total' => 0,
+							'void' => 0,
+							'uncomplete' => 0,
+							'skipped' => 0,
+							'failed' => 0,
+							'errored' => 0,
+							'exception' => 0,
+						],
+						'assertions' => [
+							'total' => 0,
+							'passed' => 0,
+							'failed' => 0
+						],
+						'exceptions' => 0,
+						'errors' => 0,
+						'duration' => 0,
+						'memory' => 0
+					]
+				])])->once
+			->exception(function($test) {
+					$test->testedInstance->setProjectName(uniqid());
+				}
+			)
+				->isInstanceOf('mageekguy\atoum\exceptions\logic\invalidArgument')
+				->hasMessage('Project name should match /^[a-z0-9_.-]+\/[a-z0-9_.-]+$/')
+		;
+	}
+
+	public function testHandleEvent()
+	{
+		$this
+			->given(
+				$client = new \mock\GuzzleHttp\Client(),
+				$this->calling($client)->request->doesNothing,
+				$runner = new \mock\mageekguy\atoum\runner(),
+				$telemetry = $this->newTestedInstance($client)
+			)
+			->if($this->function->uniqid = 'anon/' . ($project = uniqid()))
+			->when(
+				$this->testedInstance->handleEvent(atoum\test::runStart, $runner),
+				$this->testedInstance->handleEvent(atoum\runner::runStop, $runner)
+			)
+			->then
+				->mock($client)->call('request')->withArguments('POST', testedClass::defaultUrl, ['body' => json_encode([
+					'php' => null,
+					'atoum' => null,
+					'os' => php_uname('s') . ' ' . php_uname('r'),
+					'arch' => php_uname('m'),
+					'vendor' => 'anon',
+					'project' => $project,
+					'metrics' => [
+						'classes' => 1,
+						'methods' => [
+							'total' => 0,
+							'void' => 0,
+							'uncomplete' => 0,
+							'skipped' => 0,
+							'failed' => 0,
+							'errored' => 0,
+							'exception' => 0,
+						],
+						'assertions' => [
+							'total' => 0,
+							'passed' => 0,
+							'failed' => 0
+						],
+						'exceptions' => 0,
+						'errors' => 0,
+						'duration' => 0,
+						'memory' => 0
+					]
+				])])->once
+			->when(
+				$this->testedInstance->handleEvent(atoum\test::beforeTestMethod, $runner),
+				$this->testedInstance->handleEvent(atoum\runner::runStop, $runner)
+			)
+			->then
+				->mock($client)->call('request')->withArguments('POST', testedClass::defaultUrl, ['body' => json_encode([
+					'php' => null,
+					'atoum' => null,
+					'os' => php_uname('s') . ' ' . php_uname('r'),
+					'arch' => php_uname('m'),
+					'vendor' => 'anon',
+					'project' => $project,
+					'metrics' => [
+						'classes' => 1,
+						'methods' => [
+							'total' => 1,
+							'void' => 0,
+							'uncomplete' => 0,
+							'skipped' => 0,
+							'failed' => 0,
+							'errored' => 0,
+							'exception' => 0,
+						],
+						'assertions' => [
+							'total' => 0,
+							'passed' => 0,
+							'failed' => 0
+						],
+						'exceptions' => 0,
+						'errors' => 0,
+						'duration' => 0,
+						'memory' => 0
+					]
+				])])->once
+			->when(
+				$this->testedInstance->handleEvent(atoum\test::beforeTestMethod, $runner),
+				$this->testedInstance->handleEvent(atoum\runner::runStop, $runner)
+			)
+			->then
+				->mock($client)->call('request')->withArguments('POST', testedClass::defaultUrl, ['body' => json_encode([
+					'php' => null,
+					'atoum' => null,
+					'os' => php_uname('s') . ' ' . php_uname('r'),
+					'arch' => php_uname('m'),
+					'vendor' => 'anon',
+					'project' => $project,
+					'metrics' => [
+						'classes' => 1,
+						'methods' => [
+							'total' => 2,
+							'void' => 0,
+							'uncomplete' => 0,
+							'skipped' => 0,
+							'failed' => 0,
+							'errored' => 0,
+							'exception' => 0,
+						],
+						'assertions' => [
+							'total' => 0,
+							'passed' => 0,
+							'failed' => 0
+						],
+						'exceptions' => 0,
+						'errors' => 0,
+						'duration' => 0,
+						'memory' => 0
+					]
+				])])->once
+			->when(
+				$this->testedInstance->handleEvent(atoum\test::runStart, $runner),
+				$this->testedInstance->handleEvent(atoum\test::beforeTestMethod, $runner),
+				$this->testedInstance->handleEvent(atoum\runner::runStop, $runner)
+			)
+			->then
+				->mock($client)->call('request')->withArguments('POST', testedClass::defaultUrl, ['body' => json_encode([
+					'php' => null,
+					'atoum' => null,
+					'os' => php_uname('s') . ' ' . php_uname('r'),
+					'arch' => php_uname('m'),
+					'vendor' => 'anon',
+					'project' => $project,
+					'metrics' => [
+						'classes' => 2,
+						'methods' => [
+							'total' => 3,
+							'void' => 0,
+							'uncomplete' => 0,
+							'skipped' => 0,
+							'failed' => 0,
+							'errored' => 0,
+							'exception' => 0,
+						],
+						'assertions' => [
+							'total' => 0,
+							'passed' => 0,
+							'failed' => 0
+						],
+						'exceptions' => 0,
+						'errors' => 0,
+						'duration' => 0,
+						'memory' => 0
+					]
+				])])->once
+			->given(
+				$request = new \mock\Psr\Http\Message\RequestInterface(),
+				$response = new \mock\Psr\Http\Message\ResponseInterface(),
+				$this->calling($response)->getStatusCode = $code = rand(400, 599),
+				$exception = new \mock\GuzzleHttp\Exception\RequestException(uniqid(), $request, $response)
+			)
+			->if($this->calling($client)->request->throw = $exception)
+			->when($this->testedInstance->handleEvent(atoum\runner::runStop, $runner))
+			->then
+				->castToString($this->testedInstance)->isEqualTo('Unable to send your report to the telemetry: HTTP ' . $code . PHP_EOL)
+			->if($this->calling($client)->request->doesNothing)
+			->when($this->testedInstance->handleEvent(atoum\runner::runStop, $runner))
+			->then
+				->castToString($this->testedInstance)->isEqualTo('Your report has been sent to the telemetry. Thanks for sharing it with us!' . PHP_EOL)
+		;
+	}
+}


### PR DESCRIPTION
### Telemetry report

The telemetry report allow us to collect metrics from your test suites. If you want to help us improve atoum, please send us your reports.

To enable the telemetry report, add the following code to your configuration file:

```php
<?php

// .atoum.php

use mageekguy\atoum\reports;
use mageekguy\atoum\reports\telemetry;
use mageekguy\atoum\writers\std;

$script->addDefaultReport();

$telemetry = new telemetry();
$telemetry->addWriter(new std\out());
$runner->addReport($telemetry);
```

Now, each time your run your test suite, atoum will collect data and send them to the telemtry. By default, **everything is
sent anonymously**: a random project name will be generated and we'll only collect metrics. If you want to let us know who you are, add
the following lines to your configuration file:

```php
<?php 

$telemetry->readProjectNameFromComposerJson(__DIR__ . '/composer.json');

// Or

$telemetry->setProjectName('my/project');
```

The project name **must** be composer compliant.