### PR TITLE
Send the framework and version tags to the telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # `dev-master` (2.x-dev)
 
+* [#16](https://github.com/atoum/reports-extension/pull/16) Send the framework and version tags to the telemetry ([@jubianchi])
 * [#15](https://github.com/atoum/reports-extension/pull/15) Remove dependency on Guzzle and restore PHP 5.4 support ([@jubianchi])
 * [#14](https://github.com/atoum/reports-extension/pull/14) Add Atom, PHPStorm and Vim to telemetry environments ([@jubianchi])
 

--- a/classes/telemetry.php
+++ b/classes/telemetry.php
@@ -133,7 +133,8 @@ class telemetry extends asynchronous
 
 			$report = [
 				'php' => $this->score->getPhpVersion(),
-				'atoum' => $this->score->getAtoumVersion(),
+				'framework' => 'atoum',
+				'version' => $this->score->getAtoumVersion(),
 				'os' => php_uname('s') . ' ' . php_uname('r'),
 				'arch' => php_uname('m'),
 				'environment' => self::getEnvironment(),

--- a/tests/units/classes/telemetry.php
+++ b/tests/units/classes/telemetry.php
@@ -68,7 +68,8 @@ class telemetry extends atoum\test
 			->then
 				->mock($http)->call('write')->withArguments(json_encode([
 					'php' => null,
-					'atoum' => null,
+					'framework' => 'atoum',
+					'version' => null,
 					'os' => php_uname('s') . ' ' . php_uname('r'),
 					'arch' => php_uname('m'),
 					'environment' => 'unknown',
@@ -105,7 +106,8 @@ class telemetry extends atoum\test
 			->then
 				->mock($http)->call('write')->withArguments(json_encode([
 					'php' => null,
-					'atoum' => null,
+					'framework' => 'atoum',
+					'version' => null,
 					'os' => php_uname('s') . ' ' . php_uname('r'),
 					'arch' => php_uname('m'),
 					'environment' => 'unknown',
@@ -141,7 +143,8 @@ class telemetry extends atoum\test
 			->then
 				->mock($http)->call('write')->withArguments(json_encode([
 					'php' => null,
-					'atoum' => null,
+					'framework' => 'atoum',
+					'version' => null,
 					'os' => php_uname('s') . ' ' . php_uname('r'),
 					'arch' => php_uname('m'),
 					'environment' => 'unknown',
@@ -196,7 +199,8 @@ class telemetry extends atoum\test
 			->then
 				->mock($http)->call('write')->withArguments(json_encode([
 					'php' => null,
-					'atoum' => null,
+					'framework' => 'atoum',
+					'version' => null,
 					'os' => php_uname('s') . ' ' . php_uname('r'),
 					'arch' => php_uname('m'),
 					'environment' => 'unknown',
@@ -245,7 +249,8 @@ class telemetry extends atoum\test
 			->then
 				->mock($http)->call('write')->withArguments(json_encode([
 					'php' => null,
-					'atoum' => null,
+					'framework' => 'atoum',
+					'version' => null,
 					'os' => php_uname('s') . ' ' . php_uname('r'),
 					'arch' => php_uname('m'),
 					'environment' => 'unknown',
@@ -280,7 +285,8 @@ class telemetry extends atoum\test
 			->then
 				->mock($http)->call('write')->withArguments(json_encode([
 					'php' => null,
-					'atoum' => null,
+					'framework' => 'atoum',
+					'version' => null,
 					'os' => php_uname('s') . ' ' . php_uname('r'),
 					'arch' => php_uname('m'),
 					'environment' => 'unknown',
@@ -315,7 +321,8 @@ class telemetry extends atoum\test
 			->then
 				->mock($http)->call('write')->withArguments(json_encode([
 					'php' => null,
-					'atoum' => null,
+					'framework' => 'atoum',
+					'version' => null,
 					'os' => php_uname('s') . ' ' . php_uname('r'),
 					'arch' => php_uname('m'),
 					'environment' => 'unknown',
@@ -351,7 +358,8 @@ class telemetry extends atoum\test
 			->then
 				->mock($http)->call('write')->withArguments(json_encode([
 					'php' => null,
-					'atoum' => null,
+					'framework' => 'atoum',
+					'version' => null,
 					'os' => php_uname('s') . ' ' . php_uname('r'),
 					'arch' => php_uname('m'),
 					'environment' => 'unknown',
@@ -390,7 +398,8 @@ class telemetry extends atoum\test
 			->then
 				->mock($http)->call('write')->withArguments(json_encode([
 					'php' => null,
-					'atoum' => null,
+					'framework' => 'atoum',
+					'version' => null,
 					'os' => php_uname('s') . ' ' . php_uname('r'),
 					'arch' => php_uname('m'),
 					'environment' => 'unknown',
@@ -429,7 +438,8 @@ class telemetry extends atoum\test
 			->then
 				->mock($http)->call('write')->withArguments(json_encode([
 					'php' => null,
-					'atoum' => null,
+					'framework' => 'atoum',
+					'version' => null,
 					'os' => php_uname('s') . ' ' . php_uname('r'),
 					'arch' => php_uname('m'),
 					'environment' => 'unknown',


### PR DESCRIPTION
This is because we want to make the telemetry framework agnostic